### PR TITLE
Correct the stated licence to be MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "description": "get disk space I have in Linux",
   "homepage": "https://github.com/idjem/disk-space#readme",
-  "license": "ISC",
+  "license": "MIT",
   "main": "index.js",
   "maintainers": [
     {


### PR DESCRIPTION
The licence file in the root of the repo is MIT, this commit updates the package.json to correctly reflect what licence this code is released under